### PR TITLE
Bug #152685289 Order should be displayed on order completion page

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -1,6 +1,6 @@
 import moment from "moment";
 import { Template } from "meteor/templating";
-
+import { Orders, Shops, Products } from "/lib/collections";
 
 import { i18next } from "/client/api";
 
@@ -10,11 +10,6 @@ import { i18next } from "/client/api";
  *
  */
 Template.dashboardOrdersList.helpers({
-  orderStatus() {
-    if (this.workflow.status === "coreOrderCompleted") {
-      return true;
-    }
-  },
   getProductUrl() {
     const productId = this.items[0].productId;
     const getProductData = Meteor.subscribe("Product", productId);

--- a/imports/plugins/core/taxes/server/methods/methods.app-test.js
+++ b/imports/plugins/core/taxes/server/methods/methods.app-test.js
@@ -4,7 +4,7 @@ import { expect } from "meteor/practicalmeteor:chai";
 import { sinon } from "meteor/practicalmeteor:sinon";
 
 before(function () {
-  this.timeout(10000);
+  this.timeout(40000);
   Meteor._sleepForMs(7000);
 });
 


### PR DESCRIPTION
#### What does this PR do?
Ensure  that when a user has completed an order, the order should be displayed instead of the user seeing a  _No orders found_ message

#### Description of Task to be completed?
NA

#### How should this be manually tested?
- Pull recent changes to local development repository
- run `npm install` and then run `reaction` from the terminal to start up application
- Fire up application on host specified and navigate to the [Dashboard](localhost:3000/reaction/dashboard)
- Access the product page, buy a product and see the details of the product on the order completion page.

#### Any background context you want to provide?
NA

#### What are the relevant pivotal tracker stories?
#152685289 Order should be displayed on order completion page

#### Screenshots (if appropriate)
NA

#### Questions:
N/A